### PR TITLE
adds query scope for Role Model

### DIFF
--- a/src/app/Http/Controllers/RoleSelectController.php
+++ b/src/app/Http/Controllers/RoleSelectController.php
@@ -10,5 +10,8 @@ class RoleSelectController extends Controller
 {
     use OptionsBuilder;
 
-    protected $model = Role::class;
+    public function query()
+    {
+        return Role::visible();
+    }
 }

--- a/src/app/Models/Role.php
+++ b/src/app/Models/Role.php
@@ -58,4 +58,13 @@ class Role extends Model
 
         parent::delete();
     }
+
+    public function scopeVisible($query)
+    {
+        return auth()->user()->belongsToAdminGroup()
+            ? $query
+            : $query->whereHas('userGroups', function ($userGroup) {
+                $userGroup->whereId(auth()->user()->group_id);
+            });
+    }
 }


### PR DESCRIPTION
This commit ensures that users outside the Admin group can only see roles attached to their own group.